### PR TITLE
drop useless information

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The tool can be used also as a simple MCDA ranking tool with no variability (see
 
 ### Input information needed in the configuration file
 The following input information are contained in the `configuration.json` file:
-- input matrix, a table where rows represent the alternatives and the columns represent the indicators. Be sure that there is no index column but the column with the alternative names is set as index by:
+- input matrix, a table where rows represent the alternatives and the columns represent the indicators. Be sure that there is not an index column but that the column with the alternative names is set as index by:
 ```bash
-input_matrix = input_matrix.set_index('Alternatives'),
+input_matrix = input_matrix.set_index('Alternatives').
 ```
-and that there are no duplicates among the rows.
+Be also sure that there are no duplicates among the rows. If the values of one or more indicators are all the same, the indicators are dropped from the input matrix because they do not carry any information.
   - input matrix without uncertainties for the indicators (see an example here: `tests/resources/input_matrix_without_uncert.csv`)
   - input matrix with uncertainties for the indicators (see an example here: `tests/resources/input_matrix_with_uncert.csv`)
 - list with names of marginal distributions for each indicator (see an example here: `tests/resources/tobefilled`); the available distributions are 

--- a/configuration_without_uncertainty.json
+++ b/configuration_without_uncertainty.json
@@ -5,11 +5,11 @@
   "monte_carlo_runs": 0,
   "num_cores": 1,
   "weight_for_each_indicator" : {
-      "random_weights": "yes",
+      "random_weights": "no",
       "iterative": "no",
       "num_samples": 1000,
       "given_weights": [0.5, 0.5, 0.5, 0.5]
                                 },
-  "output_path": "/Users/flaminia/Desktop/MCDA_icecream_test4/"
+  "output_path": "/Users/flaminia/Desktop/test/"
 
 }

--- a/mcda/utils.py
+++ b/mcda/utils.py
@@ -18,7 +18,7 @@ def read_matrix(input_matrix_path: str) -> pd.DataFrame():
     try:
         filename = abspath(input_matrix_path)
         with open(filename, 'r') as fp:
-            test = pd.read_csv(fp, sep="[,;:]", decimal='.')
+            test = pd.read_csv(fp, sep="[,;:]", decimal='.',engine='python')
             return test
     except Exception as e:
         print(e)
@@ -107,6 +107,19 @@ def check_norm_sum_weights(weights: list) -> list:
         return norm_weights
     else:
         return weights
+
+
+def pop_indexed_elements(indexes: np.ndarray, original_list:list) -> list:
+    """ The function eliminates the values in a list corresponding to the given indexes"""
+    for i in range(len(indexes)):
+        index = indexes[i]
+        if i == 0:
+            original_list.pop(index)
+        else:
+            original_list.pop(index - i)
+    new_list=original_list
+
+    return new_list
 
 
 def plot_norm_scores_without_uncert(scores: pd.DataFrame) -> object:

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-import pytest
+from unittest import TestCase
 
 from mcda.utils import *
 
@@ -56,3 +56,17 @@ class TestUtils(unittest.TestCase):
         # Then
         assert len(out) == len(weights)
         assert sum(out) == 1.0
+
+
+    def test_pop_indexed_elements(self):
+        # Given
+        indexes = [0,2,4]
+        in_list = [1,2,3,4,5,6]
+
+        # When
+        out_list = pop_indexed_elements(indexes, in_list)
+        expected_list = [2,4,6]
+
+        # Then
+        isinstance(out_list, list)
+        TestCase.assertListEqual(self, out_list, expected_list)


### PR DESCRIPTION
If one or more indicators have only one value, the columns are dropped from the input matrix because they don't bring any information and cause some NANs in the calculations. Also, the respective weights, polarities, and marginal distributions are dropped.