### PR TITLE
rescale scores from all runs with randomness and calculate mean and std

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,17 @@ If else, N>1 and the input matrix has uncertainties associate to some or all the
 ### General information and references
 The normalization functions are implemented by following [*Langhans et al.*, 2014](https://www.sciencedirect.com/science/article/abs/pii/S1470160X14002167)
 
-The normalization functions *minmax*, t*arget* and *standardized* can produce negative or zero values, therefore a shift to positive values
+The normalization functions *minmax*, *target* and *standardized* can produce negative or zero values, therefore a shift to positive values
 is implemented so that they can be used also together with the aggregation functions *geometric* and *harmonic* (which require positive values). 
 
 The code implements 4 normalization and 4 aggregation functions. However, not all combinations are 
 meaningful or mathematically acceptable. For more details refer to Table 6 in 
 [*Gasser et al.*, 2020](https://www.sciencedirect.com/science/article/pii/S1470160X19307241)
+
+The standard deviation of rescaled scores with any form of randomness are not saved nor plotted because they cannot bring a statistically meaningful information.
+In fact, when one calculates the standard deviation after rescaling between (0,1), the denominator used in the standard deviation formula becomes smaller. 
+This results in a higher relative standard deviation compared to the mean.
+However, the higher relative standard deviation is not indicating a greater spread in the data but rather a consequence of the rescaling operation and 
+the chosen denominator in the standard deviation calculation.
 
 

--- a/configuration_without_uncertainty.json
+++ b/configuration_without_uncertainty.json
@@ -6,7 +6,7 @@
   "num_cores": 1,
   "weight_for_each_indicator" : {
       "random_weights": "yes",
-      "iterative": "no",
+      "iterative": "yes",
       "num_samples": 1000,
       "given_weights": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
                                 },

--- a/configuration_without_uncertainty.json
+++ b/configuration_without_uncertainty.json
@@ -1,15 +1,15 @@
 {
-  "input_matrix_path": "/Users/flaminia/Desktop/swiggy_icecream_MCDA/icecream_red_input_matrix.csv",
-  "marginal_distribution_for_each_indicator": ["exact", "exact", "exact", "exact"],
-  "polarity_for_each_indicator": ["+","-","+","-"],
+  "input_matrix_path": "/Users/flaminia/Documents/work/MCDA/Examples/exp2_12_alternatives.csv",
+  "marginal_distribution_for_each_indicator": ["exact", "exact", "exact", "exact", "exact", "exact", "exact", "exact"],
+  "polarity_for_each_indicator": ["+","+","+","+","+","-","-","+"],
   "monte_carlo_runs": 0,
   "num_cores": 1,
   "weight_for_each_indicator" : {
       "random_weights": "yes",
       "iterative": "no",
       "num_samples": 1000,
-      "given_weights": [0.5, 0.5, 0.5, 0.5]
+      "given_weights": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
                                 },
-  "output_path": "/Users/flaminia/Desktop/MCDA_icecream_test4/"
+  "output_path": "/Users/flaminia/Desktop/MCDA_test/"
 
 }

--- a/mcda/mcda_run.py
+++ b/mcda/mcda_run.py
@@ -163,13 +163,15 @@ def main(input_config: dict):
                 save_df(all_weights_means, config.output_file_path, 'score_means.csv')
                 save_df(all_weights_stds, config.output_file_path, 'score_stds.csv')
                 save_df(all_weights_means_normalized, config.output_file_path, 'score_means_normalized.csv')
-                save_df(all_weights_stds_normalized, config.output_file_path, 'score_stds_normalized.csv')
+                #save_df(all_weights_stds_normalized, config.output_file_path, 'score_stds_normalized.csv')
+                # the std on rescaled values is not statistically informative
                 save_df(ranks, config.output_file_path, 'ranks.csv')
             elif not bool(iterative_random_w_means) == 'False':
                 save_dict(iterative_random_w_means,config.output_file_path, 'score_means.pkl')
                 save_dict(iterative_random_w_stds, config.output_file_path, 'score_stds.pkl')
                 save_dict(iterative_random_w_means_normalized, config.output_file_path, 'score_means_normalized.pkl')
-                save_dict(iterative_random_w_stds_normalized, config.output_file_path, 'score_stds_normalized.pkl')
+                #save_dict(iterative_random_w_stds_normalized, config.output_file_path, 'score_stds_normalized.pkl')
+                # the std on rescaled values is not statistically informative
             save_config(input_config, config.output_file_path, 'configuration.json')
             # plots
             if not scores.empty:
@@ -178,8 +180,8 @@ def main(input_config: dict):
                 plot_no_norm_scores = plot_non_norm_scores_without_uncert(scores)
                 save_figure(plot_no_norm_scores, config.output_file_path, "MCDA_rough_scores_no_var.png")
             elif not all_weights_means.empty:
-                plot_weight_mean_scores = plot_mean_scores(all_weights_means, all_weights_stds)
-                plot_weight_mean_scores_norm = plot_mean_scores(all_weights_means_normalized, all_weights_stds_normalized)
+                plot_weight_mean_scores = plot_mean_scores(all_weights_means, all_weights_stds, "plot_std")
+                plot_weight_mean_scores_norm = plot_mean_scores(all_weights_means_normalized, all_weights_stds_normalized, "not_plot_std")
                 save_figure(plot_weight_mean_scores, config.output_file_path, "MCDA_rand_weights_rough_scores.png")
                 save_figure(plot_weight_mean_scores_norm, config.output_file_path, "MCDA_rand_weights_norm_scores.png")
             elif not bool(iterative_random_w_means) == 'False':
@@ -192,12 +194,10 @@ def main(input_config: dict):
                     one_random_weight_stds_normalized = iterative_random_w_stds_normalized["indicator_{}".format(index + 1)]
                     plot_weight_mean_scores = plot_mean_scores_iterative(one_random_weight_means,
                                                                          one_random_weight_stds,
-                                                                         input_matrix_no_alternatives.columns, index)
+                                                                         input_matrix_no_alternatives.columns, index, "plot_std")
                     plot_weight_mean_scores_norm = plot_mean_scores_iterative(one_random_weight_means_normalized,
                                                                          one_random_weight_stds_normalized,
-                                                                         input_matrix_no_alternatives.columns, index)
-                    int(type(plot_weight_mean_scores))
-                    int(type(plot_weight_mean_scores_norm))
+                                                                         input_matrix_no_alternatives.columns, index, "not_plot_std")
                     images.append(plot_weight_mean_scores)
                     images_norm.append(plot_weight_mean_scores_norm)
                 combine_images(images, config.output_file_path, "MCDA_one_weight_randomness_rough_scores.png")

--- a/mcda/mcda_run.py
+++ b/mcda/mcda_run.py
@@ -31,7 +31,6 @@ def main(input_config: dict):
 
     logger.info("Marginal distributions: {}".format(config.marginal_distribution_for_each_indicator))
     marginal_pdf = config.marginal_distribution_for_each_indicator
-
     if all(element == 'exact' for element in marginal_pdf):
        # every column of the input matrix represents an indicator
         num_indicators = input_matrix_no_alternatives.shape[1]
@@ -93,55 +92,63 @@ def main(input_config: dict):
             raise ValueError('If the number of Monte-Carlo runs is larger than 0, at least some of the marginal distributions are expected to be non-exact')
         # NO VARIABILITY OF INDICATORS
         else: # MC runs = 0
-            scores = pd.DataFrame()
-            all_weights_means = pd.DataFrame()
             logger.info("Start MCDA without variability for the indicators")
             t = time.time()
+            scores = pd.DataFrame()
+            all_weights_means = pd.DataFrame()
             mcda_no_var = MCDAWithoutVar(config, input_matrix_no_alternatives)
             # normalize the indicators
             normalized_indicators = mcda_no_var.normalize_indicators()
             # estimate the scores through aggregation
             if config.weight_for_each_indicator["random_weights"] == "no": # FIXED WEIGHTS
                 scores = mcda_no_var.aggregate_indicators(normalized_indicators, norm_fixed_weights)
+                normalized_scores = rescale_minmax(scores) # normalized scores
+                normalized_scores.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
             elif config.weight_for_each_indicator["random_weights"] == "yes":
                 if is_random_w_iterative == "no": # ALL RANDOMLY SAMPLED WEIGHTS (MCDA runs num_samples times)
                     logger.info("All weights are randomly sampled from a uniform distribution")
+                    all_weights_normalized = []
                     args_for_parallel_agg = [(lst, normalized_indicators) for lst in norm_random_weights]
-                    all_weights = parallelize_aggregation(args_for_parallel_agg)
-                    all_weights_means, all_weights_stds = estimate_runs_mean_std(all_weights)
+                    all_weights = parallelize_aggregation(args_for_parallel_agg) # rough scores coming from all runs
+                    for matrix in all_weights: # rescale the scores coming from all runs
+                        normalized_matrix = rescale_minmax(matrix) # all score normalization
+                        all_weights_normalized.append(normalized_matrix)
+                    all_weights_means, all_weights_stds = estimate_runs_mean_std(all_weights) # mean and std of rough scores
+                    all_weights_means_normalized, all_weights_stds_normalized = estimate_runs_mean_std(all_weights_normalized) # mean and std of norm. scores
+                    all_weights_means.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
+                    all_weights_stds.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
+                    all_weights_means_normalized.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
+                    all_weights_stds_normalized.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
                 elif is_random_w_iterative == "yes": # ONE RANDOMLY SAMPLED WEIGHT A TIME (MCDA runs (num_samples * num_indicators) times)
                     logger.info("One weight at time is randomly sampled from a uniform distribution")
+                    scores_one_random_weight_normalized = []
                     iterative_random_w_means = {}
                     iterative_random_w_stds = {}
+                    iterative_random_w_means_normalized = {}
+                    iterative_random_w_stds_normalized = {}
                     for index in range(num_indicators):
-                        norm_one_random_weight = rand_weight_per_indicator["indicator_{}".format(index+1)]
+                        norm_one_random_weight = rand_weight_per_indicator["indicator_{}".format(index+1)] # 'norm' refers to all weights, which are normalized
                         args_for_parallel_agg = [(lst, normalized_indicators) for lst in norm_one_random_weight]
-                        one_random_weight = parallelize_aggregation(args_for_parallel_agg)
-                        one_random_weight_means, one_random_weight_stds = estimate_runs_mean_std(one_random_weight)
-                        iterative_random_w_means["indicator_{}".format(index+1)] = one_random_weight_means
+                        scores_one_random_weight = parallelize_aggregation(args_for_parallel_agg)
+                        for matrix in scores_one_random_weight:
+                            matrix_normalized = rescale_minmax(matrix) # normalize scores
+                            scores_one_random_weight_normalized.append(matrix_normalized)
+                        one_random_weight_means, one_random_weight_stds = estimate_runs_mean_std(scores_one_random_weight)
+                        one_random_weight_means_normalized, one_random_weight_stds_normalized = estimate_runs_mean_std(scores_one_random_weight_normalized) # normalized mean and std
+                        one_random_weight_means.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
+                        one_random_weight_stds.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
+                        one_random_weight_means_normalized.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
+                        one_random_weight_stds_normalized.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
+                        iterative_random_w_means["indicator_{}".format(index+1)] = one_random_weight_means # create output dictionaries
                         iterative_random_w_stds["indicator_{}".format(index+1)] = one_random_weight_stds
-            # normalize the output scores (no randomness)
-            if not scores.empty: # no randomly sampled weights
-                normalized_scores = rescale_minmax(scores)
-                normalized_scores.insert(0, 'Alternatives', input_matrix.iloc[:,0])
-            elif not all_weights_means.empty: # all randomly sampled weights
-                all_weights_means.insert(0, 'Alternatives', input_matrix.iloc[:,0])
-                all_weights_stds.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
-            elif not bool(iterative_random_w_means) == 'False': # one randomly sampled weight at time
-                for index in range(num_indicators):
-                    one_random_weight_means = iterative_random_w_means["indicator_{}".format(index+1)]
-                    one_random_weight_stds = iterative_random_w_stds["indicator_{}".format(index+1)]
-                    one_random_weight_means.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
-                    one_random_weight_stds.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
-                    iterative_random_w_means["indicator_{}".format(index + 1)] = one_random_weight_means
-                    iterative_random_w_stds["indicator_{}".format(index + 1)] = one_random_weight_stds
+                        iterative_random_w_means_normalized["indicator_{}".format(index + 1)] = one_random_weight_means_normalized
+                        iterative_random_w_stds_normalized["indicator_{}".format(index + 1)] = one_random_weight_stds_normalized
             # estimate the ranks
             if not scores.empty:
                 ranks = scores.rank(pct=True)
                 ranks.insert(0, 'Alternatives', input_matrix.iloc[:,0])
             elif not all_weights_means.empty:
                 ranks = all_weights_means.rank(pct=True)
-                #ranks.insert(0, 'Alternatives', input_matrix.iloc[:, 0])
             elif not bool(iterative_random_w_means) == 'False':
                 pass
             # save output files
@@ -155,10 +162,14 @@ def main(input_config: dict):
             elif not all_weights_means.empty:
                 save_df(all_weights_means, config.output_file_path, 'score_means.csv')
                 save_df(all_weights_stds, config.output_file_path, 'score_stds.csv')
+                save_df(all_weights_means_normalized, config.output_file_path, 'score_means_normalized.csv')
+                save_df(all_weights_stds_normalized, config.output_file_path, 'score_stds_normalized.csv')
                 save_df(ranks, config.output_file_path, 'ranks.csv')
             elif not bool(iterative_random_w_means) == 'False':
                 save_dict(iterative_random_w_means,config.output_file_path, 'score_means.pkl')
                 save_dict(iterative_random_w_stds, config.output_file_path, 'score_stds.pkl')
+                save_dict(iterative_random_w_means_normalized, config.output_file_path, 'score_means_normalized.pkl')
+                save_dict(iterative_random_w_stds_normalized, config.output_file_path, 'score_stds_normalized.pkl')
             save_config(input_config, config.output_file_path, 'configuration.json')
             # plots
             if not scores.empty:
@@ -168,16 +179,29 @@ def main(input_config: dict):
                 save_figure(plot_no_norm_scores, config.output_file_path, "MCDA_rough_scores_no_var.png")
             elif not all_weights_means.empty:
                 plot_weight_mean_scores = plot_mean_scores(all_weights_means, all_weights_stds)
-                save_figure(plot_weight_mean_scores, config.output_file_path, "MCDA_weights_var.png")
+                plot_weight_mean_scores_norm = plot_mean_scores(all_weights_means_normalized, all_weights_stds_normalized)
+                save_figure(plot_weight_mean_scores, config.output_file_path, "MCDA_rand_weights_rough_scores.png")
+                save_figure(plot_weight_mean_scores_norm, config.output_file_path, "MCDA_rand_weights_norm_scores.png")
             elif not bool(iterative_random_w_means) == 'False':
                 images = []
+                images_norm = []
                 for index in range(num_indicators):
                     one_random_weight_means = iterative_random_w_means["indicator_{}".format(index + 1)]
                     one_random_weight_stds = iterative_random_w_stds["indicator_{}".format(index + 1)]
-                    plot_weight_mean_scores = plot_mean_scores_iterative(one_random_weight_means, one_random_weight_stds, input_matrix_no_alternatives.columns, index)
-                    print(type(plot_weight_mean_scores))
+                    one_random_weight_means_normalized = iterative_random_w_means_normalized["indicator_{}".format(index + 1)]
+                    one_random_weight_stds_normalized = iterative_random_w_stds_normalized["indicator_{}".format(index + 1)]
+                    plot_weight_mean_scores = plot_mean_scores_iterative(one_random_weight_means,
+                                                                         one_random_weight_stds,
+                                                                         input_matrix_no_alternatives.columns, index)
+                    plot_weight_mean_scores_norm = plot_mean_scores_iterative(one_random_weight_means_normalized,
+                                                                         one_random_weight_stds_normalized,
+                                                                         input_matrix_no_alternatives.columns, index)
+                    int(type(plot_weight_mean_scores))
+                    int(type(plot_weight_mean_scores_norm))
                     images.append(plot_weight_mean_scores)
-                combine_images(images, config.output_file_path, "MCDA_one_weight_randomness.png")
+                    images_norm.append(plot_weight_mean_scores_norm)
+                combine_images(images, config.output_file_path, "MCDA_one_weight_randomness_rough_scores.png")
+                combine_images(images_norm, config.output_file_path, "MCDA_one_weight_randomness_norm_scores.png")
             logger.info("Finished MCDA without variability: check the output files")
             elapsed = time.time() - t
             logger.info("All calculations finished in seconds {}".format(elapsed))

--- a/mcda/utils.py
+++ b/mcda/utils.py
@@ -111,7 +111,8 @@ def check_norm_sum_weights(weights: list) -> list:
 
 def plot_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
     num_of_combinations = scores.shape[1] - 1
-    fig = go.Figure(layout_yaxis_range=[scores.iloc[: , 1:].values.min()-0.5, scores.iloc[: , 1:].values.max()+0.5],layout_yaxis_title="MCDA normalized score")
+    fig = go.Figure(layout_yaxis_range=[scores.iloc[:, 1:].values.min() - 0.5, scores.iloc[:, 1:].values.max() + 0.5],
+                    layout_yaxis_title="MCDA normalized score")
     i = 0
     while i <= num_of_combinations - 1:
         fig.add_trace(go.Bar(
@@ -130,19 +131,19 @@ def plot_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
                           ticktext=scores['Alternatives'][:],
                           tickangle=45),
                       yaxis=dict(
-                          range=[scores.iloc[: , 1:].values.min()-0.5, scores.iloc[: , 1:].values.max()+0.5])
+                          range=[scores.iloc[:, 1:].values.min() - 0.5, scores.iloc[:, 1:].values.max() + 0.5])
                       )
     fig.show()
     return fig
 
 
 def plot_non_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
-    num_of_combinations = scores.shape[1]-1
+    num_of_combinations = scores.shape[1] - 1
     fig = go.Figure(layout_yaxis_title="MCDA rough score")
     i = 0
     while i <= num_of_combinations - 1:
         fig.add_trace(go.Bar(
-            name=scores.columns[i+1],
+            name=scores.columns[i + 1],
             x=scores['Alternatives'].values.tolist(),
             y=scores.iloc[:, i + 1],
         ))
@@ -160,17 +161,25 @@ def plot_non_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
     fig.show()
     return fig
 
-def plot_mean_scores(all_weights_means:pd.DataFrame, all_weights_stds:pd.DataFrame)-> object:
+
+def plot_mean_scores(all_weights_means: pd.DataFrame, all_weights_stds: pd.DataFrame, plot_std: str) -> object:
     num_of_combinations = all_weights_means.shape[1] - 1
     fig = go.Figure(layout_yaxis_title="MCDA average scores and std")
     i = 0
     while i <= num_of_combinations - 1:
-        fig.add_trace(go.Bar(
-            name=all_weights_means.columns[i + 1],
-            x=all_weights_means['Alternatives'].values.tolist(),
-            y=all_weights_means.iloc[:, i + 1],
-            error_y=dict(type='data', array=all_weights_stds.iloc[:, i + 1])
-        ))
+        if plot_std == "plot_std":
+            fig.add_trace(go.Bar(
+                name=all_weights_means.columns[i + 1],
+                x=all_weights_means['Alternatives'].values.tolist(),
+                y=all_weights_means.iloc[:, i + 1],
+                error_y=dict(type='data', array=all_weights_stds.iloc[:, i + 1])
+            ))
+        else:
+            fig.add_trace(go.Bar(
+                name=all_weights_means.columns[i + 1],
+                x=all_weights_means['Alternatives'].values.tolist(),
+                y=all_weights_means.iloc[:, i + 1]
+            ))
         i = i + 1
     fig.update_layout(barmode='group', height=600, width=1000,
                       title='<b>MCDA analysis with added randomness on the weights<b>',
@@ -186,17 +195,25 @@ def plot_mean_scores(all_weights_means:pd.DataFrame, all_weights_stds:pd.DataFra
     return fig
 
 
-def plot_mean_scores_iterative(all_weights_means:pd.DataFrame, all_weights_stds:pd.DataFrame, indicators: list, index: int)-> object:
+def plot_mean_scores_iterative(all_weights_means: pd.DataFrame, all_weights_stds: pd.DataFrame, indicators: list,
+                               index: int, plot_std: str) -> object:
     num_of_combinations = all_weights_means.shape[1] - 1
     fig = go.Figure(layout_yaxis_title="MCDA average scores and std")
     i = 0
     while i <= num_of_combinations - 1:
-        fig.add_trace(go.Bar(
-            name=all_weights_means.columns[i + 1],
-            x=all_weights_means['Alternatives'][:].values.tolist(),
-            y=all_weights_means.iloc[:, i + 1],
-            error_y=dict(type='data', array=all_weights_stds.iloc[:, i + 1])
-        ))
+        if plot_std == "plot_std":
+            fig.add_trace(go.Bar(
+                name=all_weights_means.columns[i + 1],
+                x=all_weights_means['Alternatives'][:].values.tolist(),
+                y=all_weights_means.iloc[:, i + 1],
+                error_y=dict(type='data', array=all_weights_stds.iloc[:, i + 1])
+            ))
+        else:
+            fig.add_trace(go.Bar(
+                name=all_weights_means.columns[i + 1],
+                x=all_weights_means['Alternatives'][:].values.tolist(),
+                y=all_weights_means.iloc[:, i + 1]
+            ))
         i = i + 1
     fig.update_layout(barmode='group', height=600, width=1000,
                       title="MCDA analysis with random sampled weight for the indicator '{}'".format(indicators[index]),

--- a/tests/unit_tests/test_utils_for_parallelization.py
+++ b/tests/unit_tests/test_utils_for_parallelization.py
@@ -1,0 +1,52 @@
+import unittest
+
+from mcda.utils_for_parallelization import *
+from pandas.testing import assert_frame_equal
+from statistics import mean, stdev
+
+
+
+class TestUtilsForParallelization(unittest.TestCase):
+
+    @staticmethod
+    def get_list_of_dfs():
+        data1 = [10, 2, 30]
+        data2 = [20, 2, 3]
+        data3 = [30, 2, 0.3]
+
+        df1 = pd.DataFrame(data1, columns=['numbers'])
+        df2 = pd.DataFrame(data2, columns=['numbers'])
+        df3 = pd.DataFrame(data3, columns=['numbers'])
+
+        list_of_dfs = [df1,df2,df3]
+
+        return list_of_dfs
+
+    @staticmethod
+    def get_list_of_output_dfs():
+        average1 = mean([10,20,30])
+        stand_dev1 = stdev([10,20,30])
+        average2 = mean([2, 2, 2])
+        stand_dev2 = stdev([2, 2, 2])
+        average3 = mean([30, 3, 0.3])
+        stand_dev3 = stdev([30, 3, 0.3])
+        average = pd.DataFrame([average1,average2,average3],columns=['numbers'])
+        stand_dev = pd.DataFrame([stand_dev1,stand_dev2,stand_dev3],columns=['numbers'])
+
+        list_of_dfs = [average, stand_dev]
+
+        return list_of_dfs
+
+    def test_estimate_runs_mean_std(self):
+        # Given
+        input = TestUtilsForParallelization.get_list_of_dfs()
+        output = TestUtilsForParallelization.get_list_of_output_dfs()
+
+        # When
+        res = estimate_runs_mean_std(input)
+
+        # Then
+        isinstance(res, list)
+        for i in range(2): isinstance(res[i],pd.DataFrame)
+        assert_frame_equal(res[0],output[0])
+        assert_frame_equal(res[1],output[1])


### PR DESCRIPTION
This PR arises from my wish to be able to plot not only the rough scores but also the normalized ones also in the case some randomness is added to the weights. If randomness is added to the weights, this means that MCD has N-input matrices and produces N-outputs.

The logic I have implemented is:
- one gets N-output matrices from the N-runs
- all matrices are rescaled between 0 and 1
- the mean is estimated from the rescaled matrices
- plot of normalized (i.e. rescaled) mean 
- the standard deviation of rescaled values is not statistically informative

This approach should retain the statistical properties of the rescaled values.