### PR TITLE
Implement random sampling of the indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ if instead the marginal distributions are also other than *exact*, it means that
 - `configuration_w_uncertainty.jon`
     - uncertainty relative to the indicators is considered, together with
     - the variability caused by using different pairs of normalization/aggregation functions
-    - the variability due to added randomness to the weights (optional)
 
 ### Requirements
 ```bash
@@ -91,10 +90,11 @@ Else if N=0 and the input matrix has no uncertainties associated to the indicato
 - the results of all the combinations normalization/aggregation are provided in the form of mean and std over all the runs (if the weights are iteratively sampled, this applies for num_indicators-times)
 
 If else, N>1 and the input matrix has uncertainties associate to some or all the indicators, then:
-- for each indicator, the meand and standard deviation (std) are extracted from the input matrix
+- for each indicator, the mean and standard deviation (std) are extracted from the input matrix
 - for each N, and for each indicator, a value is sampled from the relative assigned marginal distribution: one of N input matrix is created
 - normalizations and aggregations are performed as in points 1,2,3 of the case N=1: a list of all the results is created
 - mean and std of all the results are estimated across (N x pairs of combinations) 
+- in this case, no randomness on the weights is allowed
 
 
 ### General information and references

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The variability of the MCDA scores are caused by:
 
 The tool can be used also as a simple MCDA ranking tool with no variability (see also below).
 
+
 ### Input information needed in the configuration file
 The following input information are contained in the `configuration.json` file:
 - input matrix, a table where rows represent the alternatives and the columns represent the indicators. Be sure that there is not an index column but that the column with the alternative names is set as index by:
@@ -16,14 +17,14 @@ input_matrix = input_matrix.set_index('Alternatives').
 Be also sure that there are no duplicates among the rows. If the values of one or more indicators are all the same, the indicators are dropped from the input matrix because they do not carry any information.
   - input matrix without uncertainties for the indicators (see an example here: `tests/resources/input_matrix_without_uncert.csv`)
   - input matrix with uncertainties for the indicators (see an example here: `tests/resources/input_matrix_with_uncert.csv`)
+The input matrix with uncertainties has for each indicator a column with the mean values and a column with the standard deviation; 
+if the marginal distribution relative to the indicator is 'exact', then the standard deviation column contains only 0.
 - list with names of marginal distributions for each indicator (see an example here: `tests/resources/tobefilled`); the available distributions are 
   - exact, "exact",
   - uniform distribution, "uniform"
   - normal distribution, "norm
   - lognormal distribution, "lnorm"
-  - Poisson distribution, "pois"
-  - negative Binomial distribution, "ng"
-  - beta distribution, "beta"
+  - Poisson distribution, "poisson"
 - list of polarities for each indicator, "+" or "-"
 - number of Monte Carlo runs, "N" (default is 0, no variability is considered; N should be a sufficient big number, e.g. larger or equal than 1000)
 - the number of cores used for the parallelization, "numCores"
@@ -44,6 +45,18 @@ In case the variability of results is of no interest, then:
 - the marginal distribution associated to the indicators should all be of the kind "exact"
 - cores=1
 - N=1
+
+The configuration file can trigger a run with or without uncertainty on the indicators. This is implicitly set in the 
+`marginal_distribution_for_each_indicator` parameter: if the marginal distributions are all *exact*, then the run is without uncertainty;
+if instead the marginal distributions are also other than *exact*, it means that the indicator values can be randomly sampled from those PDFs.
+- `configuration_without_uncertainty.jon`
+  - no uncertainty relative to the indicators is considered, however one can
+    - see the variability caused by using different pairs of normalization/aggregation functions
+    - turn on the variability due to added randomness to the weights (optional)
+- `configuration_w_uncertainty.jon`
+    - uncertainty relative to the indicators is considered, together with
+    - the variability caused by using different pairs of normalization/aggregation functions
+    - the variability due to added randomness to the weights (optional)
 
 ### Requirements
 ```bash
@@ -85,7 +98,7 @@ If else, N>1 and the input matrix has uncertainties associate to some or all the
 
 
 ### General information and references
-The normalization functions are implemented by following [*Langhans et al.*, 2014](https://www.sciencedirect.com/science/article/abs/pii/S1470160X14002167)
+The aggregation functions are implemented by following [*Langhans et al.*, 2014](https://www.sciencedirect.com/science/article/abs/pii/S1470160X14002167)
 
 The normalization functions *minmax*, *target* and *standardized* can produce negative or zero values, therefore a shift to positive values
 is implemented so that they can be used also together with the aggregation functions *geometric* and *harmonic* (which require positive values). 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ In case the variability of results is of no interest, then:
 The configuration file can trigger a run with or without uncertainty on the indicators. This is implicitly set in the 
 `marginal_distribution_for_each_indicator` parameter: if the marginal distributions are all *exact*, then the run is without uncertainty;
 if instead the marginal distributions are also other than *exact*, it means that the indicator values can be randomly sampled from those PDFs.
-- `configuration_without_uncertainty.jon`
+- `configuration_without_uncertainty.json`
   - no uncertainty relative to the indicators is considered, however one can
     - see the variability caused by using different pairs of normalization/aggregation functions
     - turn on the variability due to added randomness to the weights (optional)
-- `configuration_w_uncertainty.jon`
+- `configuration_w_uncertainty.json`
     - uncertainty relative to the indicators is considered, together with
     - the variability caused by using different pairs of normalization/aggregation functions
 

--- a/configuration_w_uncertainty.json
+++ b/configuration_w_uncertainty.json
@@ -1,15 +1,15 @@
 {
-  "input_matrix_path": "/Users/flaminia/Desktop/swiggy_icecream_MCDA/icecream_red_input_matrix.csv",
-  "marginal_distribution_for_each_indicator": ["beta", "norm", "lnorm", "exact"],
-  "polarity_for_each_indicator": ["+","-","+","-"],
-  "monte_carlo_runs": 0,
-  "num_cores": 1,
+  "input_matrix_path": "/Users/flaminia/Documents/work/MCDA/input_matrix_12_alternatives_w_uncertainties.csv",
+  "marginal_distribution_for_each_indicator": ["normal", "normal", "normal", "normal", "normal", "exact", "exact", "exact"],
+  "polarity_for_each_indicator": ["+","+","+","+","+","+","-","-"],
+  "monte_carlo_runs": 10000,
+  "num_cores": 4,
   "weight_for_each_indicator" : {
-      "random_weights": "yes",
+      "random_weights": "no",
       "iterative": "no",
       "num_samples": 1000,
-      "given_weights": [0.5, 0.5, 0.5, 0.5]
+      "given_weights": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
                                 },
-  "output_path": "/Users/flaminia/Desktop/test4_red_matrix_no_var_rand_weights"
+  "output_path": "/Users/flaminia/Desktop/test_indicators_variability"
 
 }

--- a/configuration_w_uncertainty.json
+++ b/configuration_w_uncertainty.json
@@ -1,14 +1,15 @@
 {
-  "input_matrix_path": "/Users/flaminia/Documents/work/MCDA/tests/resources/input_matrix_with_uncert.csv",
-  "marginal_distribution_for_each_indicator": ["norm", "exact", "beta", "norm", "exact", "beta"],
-  "polarity_for_each_indicator": ["-","-","+", "+","+","+"],
-  "monte_carlo_runs": 10,
+  "input_matrix_path": "/Users/flaminia/Desktop/swiggy_icecream_MCDA/icecream_red_input_matrix.csv",
+  "marginal_distribution_for_each_indicator": ["beta", "norm", "lnorm", "exact"],
+  "polarity_for_each_indicator": ["+","-","+","-"],
+  "monte_carlo_runs": 0,
   "num_cores": 1,
   "weight_for_each_indicator" : {
       "random_weights": "yes",
-      "iterative": "yes",
-      "num_samples": 3,
-      "given_weights": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+      "iterative": "no",
+      "num_samples": 1000,
+      "given_weights": [0.5, 0.5, 0.5, 0.5]
                                 },
-  "output_path": "/path/to/output"
+  "output_path": "/Users/flaminia/Desktop/test4_red_matrix_no_var_rand_weights"
+
 }

--- a/configuration_without_uncertainty.json
+++ b/configuration_without_uncertainty.json
@@ -1,15 +1,15 @@
 {
-  "input_matrix_path": "/Users/flaminia/Desktop/swiggy_icecream_MCDA/icecream_red_input_matrix.csv",
-  "marginal_distribution_for_each_indicator": ["exact", "exact", "exact", "exact"],
-  "polarity_for_each_indicator": ["+","-","+","-"],
+ "input_matrix_path": "/Users/flaminia/Documents/work/MCDA/Examples/exp2_12_alternatives.csv",
+  "marginal_distribution_for_each_indicator": ["exact", "exact", "exact", "exact", "exact", "exact", "exact", "exact"],
+  "polarity_for_each_indicator": ["+","+","+","+","+","-","-","+"],
   "monte_carlo_runs": 0,
-  "num_cores": 1,
+  "num_cores": 4,
   "weight_for_each_indicator" : {
-      "random_weights": "yes",
+      "random_weights": "no",
       "iterative": "no",
       "num_samples": 1000,
-      "given_weights": [0.5, 0.5, 0.5, 0.5]
+      "given_weights": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
                                 },
-  "output_path": "/Users/flaminia/Desktop/test4_red_matrix_no_var_rand_weights"
+  "output_path": "/Users/flaminia/Desktop/test_indicators_no_variability"
 
 }

--- a/mcda/mcda_run.py
+++ b/mcda/mcda_run.py
@@ -230,6 +230,8 @@ def main(input_config: dict):
                 time.sleep(5)
             logger.info("Start MCDA with variability on the indicators")
             mcda_with_var = MCDAWithVar(config, input_matrix_no_alternatives)
+            n_random_input_matrices = mcda_with_var.create_n_randomly_sampled_matrices()
+            n_normalized_input_matrices = parallelize_normalization(n_random_input_matrices, polar)
         else:
             logger.error('Error Message', stack_info=True)
             raise ValueError('If the number of Monte-Carlo runs is 0, all marginal distributions are expected to be exact')

--- a/mcda/mcda_run.py
+++ b/mcda/mcda_run.py
@@ -203,8 +203,8 @@ def main(input_config: dict):
                 plot_no_norm_scores = plot_non_norm_scores_without_uncert(scores)
                 save_figure(plot_no_norm_scores, config.output_file_path, "MCDA_rough_scores_no_var.png")
             elif not all_weights_means.empty:
-                plot_weight_mean_scores = plot_mean_scores(all_weights_means, all_weights_stds, "plot_std")
-                plot_weight_mean_scores_norm = plot_mean_scores(all_weights_means_normalized, all_weights_stds_normalized, "not_plot_std")
+                plot_weight_mean_scores = plot_mean_scores(all_weights_means, all_weights_stds, "plot_std", "weights")
+                plot_weight_mean_scores_norm = plot_mean_scores(all_weights_means_normalized, all_weights_stds_normalized, "not_plot_std", "weights")
                 save_figure(plot_weight_mean_scores, config.output_file_path, "MCDA_rand_weights_rough_scores.png")
                 save_figure(plot_weight_mean_scores_norm, config.output_file_path, "MCDA_rand_weights_norm_scores.png")
             elif not bool(iterative_random_w_means) == 'False':
@@ -217,10 +217,10 @@ def main(input_config: dict):
                     one_random_weight_stds_normalized = iterative_random_w_stds_normalized["indicator_{}".format(index + 1)]
                     plot_weight_mean_scores = plot_mean_scores_iterative(one_random_weight_means,
                                                                          one_random_weight_stds,
-                                                                         input_matrix_no_alternatives.columns, index, "plot_std")
+                                                                         input_matrix_no_alternatives.columns, index, "plot_std", "weights")
                     plot_weight_mean_scores_norm = plot_mean_scores_iterative(one_random_weight_means_normalized,
                                                                          one_random_weight_stds_normalized,
-                                                                         input_matrix_no_alternatives.columns, index, "not_plot_std")
+                                                                         input_matrix_no_alternatives.columns, index, "not_plot_std", "weights")
                     images.append(plot_weight_mean_scores)
                     images_norm.append(plot_weight_mean_scores_norm)
                 combine_images(images, config.output_file_path, "MCDA_one_weight_randomness_rough_scores.png")
@@ -239,6 +239,7 @@ def main(input_config: dict):
                 logger.info("A meaningful number of Monte-Carlo runs is equal or larger than 1000")
                 time.sleep(5)
             logger.info("Start MCDA with variability on the indicators")
+            t = time.time()
             mcda_with_var = MCDAWithVar(config, input_matrix_no_alternatives)
             n_random_input_matrices = mcda_with_var.create_n_randomly_sampled_matrices() # N random matrices
             n_normalized_input_matrices = parallelize_normalization(n_random_input_matrices, polar) # parallel normalization
@@ -266,11 +267,11 @@ def main(input_config: dict):
             save_df(ranks, config.output_file_path, 'ranks.csv')
             save_config(input_config, config.output_file_path, 'configuration.json')
             # plots
-            plot_indicators_mean_scores = plot_mean_scores(all_indicators_means, all_indicators_stds, "plot_std")
+            plot_indicators_mean_scores = plot_mean_scores(all_indicators_means, all_indicators_stds, "plot_std", "indicators")
             plot_indicators_mean_scores_norm = plot_mean_scores(all_indicators_means_normalized,
-                                                                all_indicators_stds_normalized, "not_plot_std")
-            save_figure(plot_weight_mean_scores, config.output_file_path, "MCDA_rand_indicators_rough_scores.png")
-            save_figure(plot_weight_mean_scores_norm, config.output_file_path, "MCDA_rand_indicators_norm_scores.png")
+                                                                all_indicators_stds_normalized, "not_plot_std", "indicators")
+            save_figure(plot_indicators_mean_scores, config.output_file_path, "MCDA_rand_indicators_rough_scores.png")
+            save_figure(plot_indicators_mean_scores_norm, config.output_file_path, "MCDA_rand_indicators_norm_scores.png")
             logger.info("Finished MCDA with variability of the indicators: check the output files")
             elapsed = time.time() - t
             logger.info("All calculations finished in seconds {}".format(elapsed))

--- a/mcda/mcda_with_variability.py
+++ b/mcda/mcda_with_variability.py
@@ -7,8 +7,6 @@ import numpy as np
 
 from mcda.configuration.config import Config
 from mcda.mcda_without_variability import MCDAWithoutVar
-from mcda.utility_functions.normalization import Normalization
-from mcda.utility_functions.aggregation import Aggregation
 
 formatter = '%(levelname)s: %(asctime)s - %(name)s - %(message)s'
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format=formatter)
@@ -38,7 +36,7 @@ class MCDAWithVar(MCDAWithoutVar):
         """
 
         data_list = [initial_series[:] for _ in range(num_runs)]
-        out_df = pd.DataFrame(data_list).T
+        out_df = pd.DataFrame(data_list,index=range(num_runs)).T
 
         return out_df
 
@@ -54,7 +52,7 @@ class MCDAWithVar(MCDAWithoutVar):
 
         for i, df in enumerate(data_list):
             for n in range(num_runs):
-                transposed_list[n][i] = df[n]
+                transposed_list[n][i] = df.iloc[:,n]
 
         return transposed_list
 
@@ -94,7 +92,7 @@ class MCDAWithVar(MCDAWithoutVar):
             if distribution_type == 'exact':
                 if any(stds != 0):
                     raise ValueError('There are stds != 0 for *exact* marginal distribution')
-                samples = self.repeat_series_to_create_df(means)
+                samples = self.repeat_series_to_create_df(means, num_runs).T
             elif distribution_type == 'normal':
                 samples = np.random.normal(loc=means, scale=stds, size=(num_runs, len(means)))
             elif distribution_type == 'uniform':

--- a/mcda/mcda_with_variability.py
+++ b/mcda/mcda_with_variability.py
@@ -7,7 +7,6 @@ import numpy as np
 
 
 from mcda.configuration.config import Config
-from mcda.mcda_without_variability import MCDAWithoutVar
 
 formatter = '%(levelname)s: %(asctime)s - %(name)s - %(message)s'
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format=formatter)
@@ -24,7 +23,6 @@ class MCDAWithVar():
     """
 
     def __init__(self, config: Config, input_matrix: pd.DataFrame()):
-        super().__init__(config, input_matrix)
         self._config = copy.deepcopy(config)
         self._input_matrix = copy.deepcopy(input_matrix)
 
@@ -78,9 +76,6 @@ class MCDAWithVar():
 
         sampled_matrices = [] # list long I
 
-        if len(input_matrix.columns) % 2 != 0:
-            raise ValueError("Number of columns in the input matrix must be even.")
-
         for i in range(0, len(input_matrix.columns), 2):  # over indicators (every second value)
             mean_col = input_matrix.columns[i]
             std_col = input_matrix.columns[i + 1]
@@ -92,7 +87,7 @@ class MCDAWithVar():
 
             if distribution_type == 'exact':
                 if any(stds != 0):
-                    raise ValueError('There are stds != 0 for *exact* marginal distribution')
+                    raise ValueError('Also for *exact* marginal distributions you need a column representing std=0')
                 samples = self.repeat_series_to_create_df(means, num_runs).T
             elif distribution_type == 'normal':
                 samples = np.random.normal(loc=means, scale=stds, size=(num_runs, len(means)))

--- a/mcda/mcda_with_variability.py
+++ b/mcda/mcda_with_variability.py
@@ -1,0 +1,114 @@
+import sys
+import copy
+import logging
+import pandas as pd
+import numpy as np
+
+
+from mcda.configuration.config import Config
+from mcda.mcda_without_variability import MCDAWithoutVar
+from mcda.utility_functions.normalization import Normalization
+from mcda.utility_functions.aggregation import Aggregation
+
+formatter = '%(levelname)s: %(asctime)s - %(name)s - %(message)s'
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format=formatter)
+logger = logging.getLogger("MCDA with variability")
+
+class MCDAWithVar(MCDAWithoutVar):
+    """
+    Class MCDA with indicators' variability: inherits from the parent class MCDAWithoutVar
+
+    This class allows one to run MCDA by considering the uncertainties related to the indicators.
+    All indicator values are randomly sampled by different distributions.
+    It's possible to have randomly sampled weights too.
+
+    """
+
+    def __init__(self, config: Config, input_matrix: pd.DataFrame()):
+        super().__init__(config, input_matrix)
+        self._config = copy.deepcopy(config)
+        self._input_matrix = copy.deepcopy(input_matrix)
+
+    @staticmethod
+    def repeat_series_to_create_df(initial_series: pd.Series, num_runs:int) -> pd.DataFrame:
+        """
+        This is a helper function to create a (AxN) df by concatenating
+        a seires of values of length A for N times. This reproduces a fake random
+        sampling in case an indicator has an exact marginal distribution.
+        """
+
+        data_list = [initial_series[:] for _ in range(num_runs)]
+        out_df = pd.DataFrame(data_list).T
+
+        return out_df
+
+    @staticmethod
+    def convert_list(data_list):
+        """
+        This is a helper function to convert a list of length I of (AxN) dfs
+        into a list of length N of (AxI) dfs.
+        """
+        alternatives, num_runs = data_list[0].shape
+
+        transposed_list = [pd.DataFrame(index=range(alternatives)) for _ in range(num_runs)]
+
+        for i, df in enumerate(data_list):
+            for n in range(num_runs):
+                transposed_list[n][i] = df[n]
+
+        return transposed_list
+
+    def create_n_randomly_sampled_matrices(self) -> list[pd.DataFrame]:
+        """
+        This function receives an input matrix of dimensions (Ax2I), its columns represent means and standard deviations
+        of each indicator. In a first step, it produces a list of length I of matrices of dimension (AxN).
+        Every matrix represents the N random samples of every alternative (A), per indicator (I).
+        In a second step, a utility function converts this list into a list of length N of matrices of dimension (AxI).
+        The output is therefore a list containing N randomly sampled input matrices. The PDFs from where random values
+        are sampled depends on the indicator marginal distributions.
+
+        A: all alternatives
+        I: all indicators
+        N: number of random samples
+        """
+        marginal_pdf = self._config.marginal_distribution_for_each_indicator
+        num_runs = self._config.monte_carlo_runs # N
+        input_matrix = self._input_matrix # (AxI)
+
+        np.random.seed(42)
+
+        sampled_matrices = [] # list long I
+
+        if len(input_matrix.columns) % 2 != 0:
+            raise ValueError("Number of columns in the input matrix must be even.")
+
+        for i in range(0, len(input_matrix.columns), 2):  # over indicators (every second value)
+            mean_col = input_matrix.columns[i]
+            std_col = input_matrix.columns[i + 1]
+
+            means = input_matrix[mean_col].values
+            stds = input_matrix[std_col].values
+
+            distribution_type = marginal_pdf[i // 2]
+
+            if distribution_type == 'exact':
+                if any(stds != 0):
+                    raise ValueError('There are stds != 0 for *exact* marginal distribution')
+                samples = self.repeat_series_to_create_df(means)
+            elif distribution_type == 'normal':
+                samples = np.random.normal(loc=means, scale=stds, size=(num_runs, len(means)))
+            elif distribution_type == 'uniform':
+                samples = np.random.uniform(low=means - stds, high=means + stds, size=(num_runs, len(means)))
+            elif distribution_type == 'lnorm':
+                samples = np.random.lognormal(mean=means, sigma=stds, size=(num_runs, len(means)))
+            elif distribution_type == 'poisson':
+                samples = np.random.poisson(lam=means, size=(num_runs, len(means)))
+            else:
+                raise ValueError(f"Invalid marginal distribution type: {distribution_type}")
+
+            sampled_df = pd.DataFrame(samples.transpose()) # (AxN)
+            sampled_matrices.append(sampled_df)
+
+        list_random_matrix = self.convert_list(sampled_matrices)
+
+        return list_random_matrix

--- a/mcda/mcda_with_variability.py
+++ b/mcda/mcda_with_variability.py
@@ -1,6 +1,7 @@
 import sys
 import copy
 import logging
+from typing import List
 import pandas as pd
 import numpy as np
 
@@ -12,9 +13,9 @@ formatter = '%(levelname)s: %(asctime)s - %(name)s - %(message)s'
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format=formatter)
 logger = logging.getLogger("MCDA with variability")
 
-class MCDAWithVar(MCDAWithoutVar):
+class MCDAWithVar():
     """
-    Class MCDA with indicators' variability: inherits from the parent class MCDAWithoutVar
+    Class MCDA with indicators' variability
 
     This class allows one to run MCDA by considering the uncertainties related to the indicators.
     All indicator values are randomly sampled by different distributions.
@@ -31,7 +32,7 @@ class MCDAWithVar(MCDAWithoutVar):
     def repeat_series_to_create_df(initial_series: pd.Series, num_runs:int) -> pd.DataFrame:
         """
         This is a helper function to create a (AxN) df by concatenating
-        a seires of values of length A for N times. This reproduces a fake random
+        a series of values of length A for N times. This reproduces a fake random
         sampling in case an indicator has an exact marginal distribution.
         """
 
@@ -56,9 +57,9 @@ class MCDAWithVar(MCDAWithoutVar):
 
         return transposed_list
 
-    def create_n_randomly_sampled_matrices(self) -> list[pd.DataFrame]:
+    def create_n_randomly_sampled_matrices(self) -> List[pd.DataFrame]:
         """
-        This function receives an input matrix of dimensions (Ax2I), its columns represent means and standard deviations
+        This function receives an input matrix of dimensions (Ax2I) whose columns represent means and standard deviations
         of each indicator. In a first step, it produces a list of length I of matrices of dimension (AxN).
         Every matrix represents the N random samples of every alternative (A), per indicator (I).
         In a second step, a utility function converts this list into a list of length N of matrices of dimension (AxI).

--- a/mcda/utility_functions/normalization.py
+++ b/mcda/utility_functions/normalization.py
@@ -125,7 +125,7 @@ class Normalization(object):
                 indicators_scaled_target_minus = (1 - indicators_minus / indicators_minus.max(axis=0)) * (
                             1 - 0.1) + 0.1  # for - polarity
         else:
-            raise ValueError('Indicators in the input matrix should have all positive values.')
+            raise ValueError('Indicators in the input matrix should have all positive values, larger than 0.')
 
         # merge back scaled values for positive and negative polarities
         indicators_scaled_target = pd.DataFrame(index=range(original_shape[0]), columns=range(original_shape[1]))

--- a/mcda/utils.py
+++ b/mcda/utils.py
@@ -175,33 +175,33 @@ def plot_non_norm_scores_without_uncert(scores: pd.DataFrame) -> object:
     return fig
 
 
-def plot_mean_scores(all_weights_means: pd.DataFrame, all_weights_stds: pd.DataFrame, plot_std: str) -> object:
-    num_of_combinations = all_weights_means.shape[1] - 1
+def plot_mean_scores(all_means: pd.DataFrame, all_stds: pd.DataFrame, plot_std: str, rand_on: str) -> object:
+    num_of_combinations = all_means.shape[1] - 1
     fig = go.Figure(layout_yaxis_title="MCDA average scores and std")
     i = 0
     while i <= num_of_combinations - 1:
         if plot_std == "plot_std":
             fig.add_trace(go.Bar(
-                name=all_weights_means.columns[i + 1],
-                x=all_weights_means['Alternatives'].values.tolist(),
-                y=all_weights_means.iloc[:, i + 1],
-                error_y=dict(type='data', array=all_weights_stds.iloc[:, i + 1])
+                name=all_means.columns[i + 1],
+                x=all_means['Alternatives'].values.tolist(),
+                y=all_means.iloc[:, i + 1],
+                error_y=dict(type='data', array=all_stds.iloc[:, i + 1])
             ))
         else:
             fig.add_trace(go.Bar(
-                name=all_weights_means.columns[i + 1],
-                x=all_weights_means['Alternatives'].values.tolist(),
-                y=all_weights_means.iloc[:, i + 1]
+                name=all_means.columns[i + 1],
+                x=all_means['Alternatives'].values.tolist(),
+                y=all_means.iloc[:, i + 1]
             ))
         i = i + 1
     fig.update_layout(barmode='group', height=600, width=1000,
-                      title='<b>MCDA analysis with added randomness on the weights<b>',
+                      title=f'<b>MCDA analysis with added randomness on the {rand_on}<b>',
                       title_font_size=22,
 
                       xaxis=dict(
                           tickmode="array",
-                          tickvals=np.arange(0, len(all_weights_means['Alternatives'][:])),
-                          ticktext=all_weights_means['Alternatives'][:],
+                          tickvals=np.arange(0, len(all_means['Alternatives'][:])),
+                          ticktext=all_means['Alternatives'][:],
                           tickangle=45)
                       )
     fig.show()

--- a/mcda/utils.py
+++ b/mcda/utils.py
@@ -18,8 +18,8 @@ def read_matrix(input_matrix_path: str) -> pd.DataFrame():
     try:
         filename = abspath(input_matrix_path)
         with open(filename, 'r') as fp:
-            test = pd.read_csv(fp, sep="[,;:]", decimal='.',engine='python')
-            return test
+            matrix = pd.read_csv(fp, sep="[,;:]", decimal='.',engine='python')
+            return matrix
     except Exception as e:
         print(e)
 

--- a/mcda/utils_for_parallelization.py
+++ b/mcda/utils_for_parallelization.py
@@ -1,18 +1,50 @@
 from mcda.utility_functions.aggregation import Aggregation
+from mcda.utility_functions.normalization import Normalization
 import pandas as pd
 import multiprocessing
 from typing import List, Tuple
 
+
 def initialize_and_call_aggregation(args: Tuple[list, dict]) -> pd.DataFrame:
-    weights,data = args
+    weights, data = args
     agg = Aggregation(weights)
 
-    scores_one_run = aggregate_indicators_in_parallel(agg,data)
+    scores_one_run = aggregate_indicators_in_parallel(agg, data)
 
     return scores_one_run
 
-def aggregate_indicators_in_parallel(agg: object, normalized_indicators: dict) -> pd.DataFrame():
 
+def initialize_and_call_normalization(args: Tuple[pd.DataFrame, list]) -> List[dict]:
+    matrix, polarities = args
+    norm = Normalization(matrix, polarities)
+
+    dict_normalized_matrix = normalize_indicators_in_parallel(norm, matrix)
+
+    return dict_normalized_matrix
+
+
+def normalize_indicators_in_parallel(norm: object, input_matrix: pd.DataFrame) -> dict:
+    indicators_scaled_minmax_01 = norm.minmax(feature_range=(0, 1))
+    indicators_scaled_minmax_no0 = norm.minmax(feature_range=(0.1, 1)) # for aggregation "geometric" and "harmonic" that accept no 0
+    indicators_scaled_target_01 = norm.target(feature_range=(0, 1))
+    indicators_scaled_target_no0 = norm.target(feature_range=(0.1, 1)) # for aggregation "geometric" and "harmonic" that accept no 0
+    indicators_scaled_standardized_any = norm.standardized(feature_range=('-inf', '+inf'))
+    indicators_scaled_standardized_no0 = norm.standardized(feature_range=(0.1, '+inf'))
+    indicators_scaled_rank = norm.rank()
+
+    normalized_indicators = {"standardized_any": indicators_scaled_standardized_any,
+                             "standardized_no0": indicators_scaled_standardized_no0,
+                             "minmax_01":  indicators_scaled_minmax_01,
+                             "minmax_no0": indicators_scaled_minmax_no0,
+                             "target_01":  indicators_scaled_target_01,
+                             "target_no0": indicators_scaled_target_no0,
+                             "rank":  indicators_scaled_rank
+                            }
+
+    return normalized_indicators
+
+
+def aggregate_indicators_in_parallel(agg: object, normalized_indicators: dict) -> pd.DataFrame():
     scores_weighted_sum_standardized = agg.weighted_sum(normalized_indicators["standardized_any"])
     scores_weighted_sum_minmax = agg.weighted_sum(normalized_indicators["minmax_01"])
     scores_weighted_sum_target = agg.weighted_sum(normalized_indicators["target_01"])
@@ -45,8 +77,8 @@ def aggregate_indicators_in_parallel(agg: object, normalized_indicators: dict) -
 
     return scores
 
-def parallelize_aggregation(args: List[tuple]) -> List[pd.DataFrame]:
 
+def parallelize_aggregation(args: List[tuple]) -> List[pd.DataFrame]:
     # create a synchronous multiprocessing pool with the desired number of processes
     pool = multiprocessing.Pool()
     res = pool.map(initialize_and_call_aggregation, args)
@@ -55,7 +87,19 @@ def parallelize_aggregation(args: List[tuple]) -> List[pd.DataFrame]:
 
     return res
 
-def estimate_runs_mean_std(res: List[pd.DataFrame])->List[pd.DataFrame]:
+
+def parallelize_normalization(input_matrices: List[pd.DataFrame], polar: list) -> List[dict]:
+    # create a synchronous multiprocessing pool with the desired number of processes
+    pool = multiprocessing.Pool()
+    args_for_parallel_norm = [(df, polar) for df in input_matrices]
+    res = pool.map(initialize_and_call_normalization, args_for_parallel_norm)
+    pool.close()
+    pool.join()
+
+    return res
+
+
+def estimate_runs_mean_std(res: List[pd.DataFrame]) -> List[pd.DataFrame]:
     all_runs = pd.concat(res, axis=0)
     by_index = all_runs.groupby(all_runs.index)
     df_means = by_index.mean()

--- a/tests/unit_tests/test_mcda_wihout_variability.py
+++ b/tests/unit_tests/test_mcda_wihout_variability.py
@@ -1,8 +1,6 @@
 import unittest
 from unittest import TestCase
 
-import pandas as pd
-
 from mcda.mcda_without_variability import MCDAWithoutVar
 from mcda.configuration.config import Config
 from mcda.utils import *

--- a/tests/unit_tests/test_mcda_with_variability.py
+++ b/tests/unit_tests/test_mcda_with_variability.py
@@ -1,0 +1,139 @@
+import pandas as pd
+import numpy as np
+import unittest
+from unittest import TestCase
+
+from mcda.mcda_with_variability import MCDAWithVar
+from mcda.configuration.config import Config
+
+class TestMCDA_with_variability(unittest.TestCase):
+
+    @staticmethod
+    def get_test_config():
+        return {
+            "input_matrix_path": "/path/to/input_matrix.csv",
+            "marginal_distribution_for_each_indicator": ['exact', 'uniform', 'normal'],
+            "polarity_for_each_indicator": ["-","-","+"],
+            "monte_carlo_runs": 10,
+            "num_cores": 1,
+            "weight_for_each_indicator" : {
+                 "random_weights": "no",
+                 "iterative": "no",
+                 "num_samples": 10000,
+                 "given_weights": [0.5, 0.5, 0.5]
+                                          },
+            "output_path": "/path/to/output"
+        }
+
+    @staticmethod
+    def get_input_matrix() -> pd.DataFrame:
+        data = {'ind1': [0, 1, 2, 3], 'std1': [0, 0, 0, 0], 'ind2': [4, 5, 6, 7], 'std2': [0.1, 0.1, 0.1, 0.1],
+                'ind3': [8, 9, 10, 11], 'std3': [0.1, 0.1, 0.1, 0.1]}
+        df = pd.DataFrame(data=data)
+
+        return df
+
+    @staticmethod
+    def get_input_list() -> list[pd.DataFrame]:
+        data = {'0': [0, 1, 2, 3], '1': [4, 5, 6, 7], '2': [8, 9, 10, 11], '3': [12, 13, 14, 15], '4': [16, 17, 18, 19] }
+        df = pd.DataFrame(data=data)
+        out_list = [df, df, df]
+
+        return out_list
+
+    @staticmethod
+    def get_expected_out_list() -> list[pd.DataFrame]:
+        data1 = {'0': [0, 1, 2, 3], '1': [0, 1, 2, 3], '2': [0, 1, 2, 3]}
+        data2 = {'0': [4, 5, 6, 7], '1': [4, 5, 6, 7], '2': [4, 5, 6, 7]}
+        data3 = {'0': [8, 9, 10, 11], '1': [8, 9, 10, 11], '2': [8, 9, 10, 11]}
+        data4 = {'0': [12, 13, 14, 15], '1': [12, 13, 14, 15], '2': [12, 13, 14, 15]}
+        data5 = {'0': [16, 17, 18, 19], '1': [16, 17, 18, 19], '2': [16, 17, 18, 19]}
+        data = [data1,data2,data3,data4,data5]
+        out_list = []
+        for i in range(0,5):
+            df_name = pd.DataFrame(data=data[i])
+            out_list.append(df_name)
+
+        return out_list
+
+
+    @staticmethod
+    def get_list_random_input_matrices() -> list[pd.DataFrame]:
+        np.random.seed(42)
+        data1 = pd.DataFrame(data = {'0': [0,1,2,3],'1': [0,1,2,3],'2': [0,1,2,3],'3': [0,1,2,3],'4': [0,1,2,3],
+                                     '5': [0,1,2,3],'6': [0,1,2,3],'7': [0,1,2,3],'8': [0,1,2,3],'9': [0,1,2,3]})
+        data2 = np.random.uniform(low=5.5 - 0.1, high=5.5 + 0.1, size=(4, 10))
+        data2 = pd.DataFrame(data2)
+        data3 = np.random.normal(loc=9.5, scale=0.1, size=(4, 10))
+        data3 = pd.DataFrame(data3)
+        out_list = [data1, data2, data3]
+        print('out_list',out_list)
+
+        input_matrix = TestMCDA_with_variability.get_input_matrix()
+        config = TestMCDA_with_variability.get_test_config()
+        config = Config(config)
+        MCDA_w_var = MCDAWithVar(config, input_matrix)
+        output_list = MCDA_w_var.convert_list(out_list)
+        print('output_list',output_list)
+
+        return output_list
+
+
+    def test_repeat_series_to_create_df(self):
+        # Given
+        input_matrix = self.get_input_matrix()
+        input_series = input_matrix.iloc[:,0]
+        config = TestMCDA_with_variability.get_test_config()
+        config = Config(config)
+        num_runs = 10
+        exp_matrix = pd.DataFrame(data = {'0': [0,1,2,3],'1': [0,1,2,3],'2': [0,1,2,3],'3': [0,1,2,3],'4': [0,1,2,3],
+                                          '5': [0,1,2,3],'6': [0,1,2,3],'7': [0,1,2,3],'8': [0,1,2,3],'9': [0,1,2,3]})
+
+        # When
+        MCDA_w_var = MCDAWithVar(config, input_matrix)
+        output_matrix = MCDA_w_var.repeat_series_to_create_df(input_series,num_runs)
+
+        # Then
+        assert isinstance(output_matrix, pd.DataFrame)
+        assert exp_matrix.values.all() == output_matrix.values.all()
+        assert exp_matrix.values.shape == output_matrix.shape
+
+
+    def test_convert_list(self):
+        # Given
+        input_matrix = self.get_input_matrix()
+        config = TestMCDA_with_variability.get_test_config()
+        input_list = TestMCDA_with_variability.get_input_list()
+        expected_output_list = TestMCDA_with_variability.get_expected_out_list()
+
+        # When
+        config = Config(config)
+        MCDA_w_var = MCDAWithVar(config, input_matrix)
+        output_list = MCDA_w_var.convert_list(input_list)
+
+        # Then
+        assert isinstance(output_list, list)
+        assert len(output_list) == 5
+        for df1,df2 in zip(output_list,expected_output_list):
+            assert df1.shape == (4,3)
+            assert df1.values.all() == df2.values.all()
+
+
+    def test_create_n_randomly_sampled_matrices(self):
+         # Given
+         input_matrix = self.get_input_matrix()
+         config = TestMCDA_with_variability.get_test_config()
+
+         # When
+         config = Config(config)
+         MCDA_w_var = MCDAWithVar(config, input_matrix)
+         n_random_matrices = MCDA_w_var.create_n_randomly_sampled_matrices()
+         exp_n_random_matrices = TestMCDA_with_variability.get_list_random_input_matrices()
+
+         # Then
+         assert isinstance(n_random_matrices, list)
+         assert len(n_random_matrices) == config.monte_carlo_runs
+         for df1,df2 in zip(n_random_matrices,exp_n_random_matrices):
+             assert df1.shape == (4, 3)
+             assert df1.values.all() == df2.values.all()
+

--- a/tests/unit_tests/test_mcda_with_variability.py
+++ b/tests/unit_tests/test_mcda_with_variability.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from mcda.mcda_with_variability import MCDAWithVar
 from mcda.configuration.config import Config
 
+
 class TestMCDA_with_variability(unittest.TestCase):
 
     @staticmethod
@@ -13,15 +14,15 @@ class TestMCDA_with_variability(unittest.TestCase):
         return {
             "input_matrix_path": "/path/to/input_matrix.csv",
             "marginal_distribution_for_each_indicator": ['exact', 'uniform', 'normal'],
-            "polarity_for_each_indicator": ["-","-","+"],
+            "polarity_for_each_indicator": ["-", "-", "+"],
             "monte_carlo_runs": 10,
             "num_cores": 1,
-            "weight_for_each_indicator" : {
-                 "random_weights": "no",
-                 "iterative": "no",
-                 "num_samples": 10000,
-                 "given_weights": [0.5, 0.5, 0.5]
-                                          },
+            "weight_for_each_indicator": {
+                "random_weights": "no",
+                "iterative": "no",
+                "num_samples": 10000,
+                "given_weights": [0.5, 0.5, 0.5]
+            },
             "output_path": "/path/to/output"
         }
 
@@ -35,7 +36,7 @@ class TestMCDA_with_variability(unittest.TestCase):
 
     @staticmethod
     def get_input_list() -> list[pd.DataFrame]:
-        data = {'0': [0, 1, 2, 3], '1': [4, 5, 6, 7], '2': [8, 9, 10, 11], '3': [12, 13, 14, 15], '4': [16, 17, 18, 19] }
+        data = {'0': [0, 1, 2, 3], '1': [4, 5, 6, 7], '2': [8, 9, 10, 11], '3': [12, 13, 14, 15], '4': [16, 17, 18, 19]}
         df = pd.DataFrame(data=data)
         out_list = [df, df, df]
 
@@ -48,56 +49,54 @@ class TestMCDA_with_variability(unittest.TestCase):
         data3 = {'0': [8, 9, 10, 11], '1': [8, 9, 10, 11], '2': [8, 9, 10, 11]}
         data4 = {'0': [12, 13, 14, 15], '1': [12, 13, 14, 15], '2': [12, 13, 14, 15]}
         data5 = {'0': [16, 17, 18, 19], '1': [16, 17, 18, 19], '2': [16, 17, 18, 19]}
-        data = [data1,data2,data3,data4,data5]
+        data = [data1, data2, data3, data4, data5]
         out_list = []
-        for i in range(0,5):
+        for i in range(0, 5):
             df_name = pd.DataFrame(data=data[i])
             out_list.append(df_name)
 
         return out_list
 
-
     @staticmethod
     def get_list_random_input_matrices() -> list[pd.DataFrame]:
         np.random.seed(42)
-        data1 = pd.DataFrame(data = {'0': [0,1,2,3],'1': [0,1,2,3],'2': [0,1,2,3],'3': [0,1,2,3],'4': [0,1,2,3],
-                                     '5': [0,1,2,3],'6': [0,1,2,3],'7': [0,1,2,3],'8': [0,1,2,3],'9': [0,1,2,3]})
+        data1 = pd.DataFrame(
+            data={'0': [0, 1, 2, 3], '1': [0, 1, 2, 3], '2': [0, 1, 2, 3], '3': [0, 1, 2, 3], '4': [0, 1, 2, 3],
+                  '5': [0, 1, 2, 3], '6': [0, 1, 2, 3], '7': [0, 1, 2, 3], '8': [0, 1, 2, 3], '9': [0, 1, 2, 3]})
         data2 = np.random.uniform(low=5.5 - 0.1, high=5.5 + 0.1, size=(4, 10))
         data2 = pd.DataFrame(data2)
         data3 = np.random.normal(loc=9.5, scale=0.1, size=(4, 10))
         data3 = pd.DataFrame(data3)
         out_list = [data1, data2, data3]
-        print('out_list',out_list)
+        print('out_list', out_list)
 
         input_matrix = TestMCDA_with_variability.get_input_matrix()
         config = TestMCDA_with_variability.get_test_config()
         config = Config(config)
         MCDA_w_var = MCDAWithVar(config, input_matrix)
         output_list = MCDA_w_var.convert_list(out_list)
-        print('output_list',output_list)
 
         return output_list
-
 
     def test_repeat_series_to_create_df(self):
         # Given
         input_matrix = self.get_input_matrix()
-        input_series = input_matrix.iloc[:,0]
+        input_series = input_matrix.iloc[:, 0]
         config = TestMCDA_with_variability.get_test_config()
         config = Config(config)
         num_runs = 10
-        exp_matrix = pd.DataFrame(data = {'0': [0,1,2,3],'1': [0,1,2,3],'2': [0,1,2,3],'3': [0,1,2,3],'4': [0,1,2,3],
-                                          '5': [0,1,2,3],'6': [0,1,2,3],'7': [0,1,2,3],'8': [0,1,2,3],'9': [0,1,2,3]})
+        exp_matrix = pd.DataFrame(
+            data={'0': [0, 1, 2, 3], '1': [0, 1, 2, 3], '2': [0, 1, 2, 3], '3': [0, 1, 2, 3], '4': [0, 1, 2, 3],
+                  '5': [0, 1, 2, 3], '6': [0, 1, 2, 3], '7': [0, 1, 2, 3], '8': [0, 1, 2, 3], '9': [0, 1, 2, 3]})
 
         # When
         MCDA_w_var = MCDAWithVar(config, input_matrix)
-        output_matrix = MCDA_w_var.repeat_series_to_create_df(input_series,num_runs)
+        output_matrix = MCDA_w_var.repeat_series_to_create_df(input_series, num_runs)
 
         # Then
         assert isinstance(output_matrix, pd.DataFrame)
         assert exp_matrix.values.all() == output_matrix.values.all()
         assert exp_matrix.values.shape == output_matrix.shape
-
 
     def test_convert_list(self):
         # Given
@@ -114,26 +113,24 @@ class TestMCDA_with_variability(unittest.TestCase):
         # Then
         assert isinstance(output_list, list)
         assert len(output_list) == 5
-        for df1,df2 in zip(output_list,expected_output_list):
-            assert df1.shape == (4,3)
+        for df1, df2 in zip(output_list, expected_output_list):
+            assert df1.shape == (4, 3)
             assert df1.values.all() == df2.values.all()
 
-
     def test_create_n_randomly_sampled_matrices(self):
-         # Given
-         input_matrix = self.get_input_matrix()
-         config = TestMCDA_with_variability.get_test_config()
+        # Given
+        input_matrix = self.get_input_matrix()
+        config = TestMCDA_with_variability.get_test_config()
 
-         # When
-         config = Config(config)
-         MCDA_w_var = MCDAWithVar(config, input_matrix)
-         n_random_matrices = MCDA_w_var.create_n_randomly_sampled_matrices()
-         exp_n_random_matrices = TestMCDA_with_variability.get_list_random_input_matrices()
+        # When
+        config = Config(config)
+        MCDA_w_var = MCDAWithVar(config, input_matrix)
+        n_random_matrices = MCDA_w_var.create_n_randomly_sampled_matrices()
+        exp_n_random_matrices = TestMCDA_with_variability.get_list_random_input_matrices()
 
-         # Then
-         assert isinstance(n_random_matrices, list)
-         assert len(n_random_matrices) == config.monte_carlo_runs
-         for df1,df2 in zip(n_random_matrices,exp_n_random_matrices):
-             assert df1.shape == (4, 3)
-             assert df1.values.all() == df2.values.all()
-
+        # Then
+        assert isinstance(n_random_matrices, list)
+        assert len(n_random_matrices) == config.monte_carlo_runs
+        for df1, df2 in zip(n_random_matrices, exp_n_random_matrices):
+            assert df1.shape == (4, 3)
+            assert df1.values.all() == df2.values.all()


### PR DESCRIPTION
This PR concludes the implementation of MCDA except for the spatial component. In particular, the random sampling of all indicator values from given marginal distributions is now allowed. It results in an analysis of the mean scores and relative stds across N-runs of MCDA.

The normalization and aggregation processes are parallelized. The job runs in ~55 seconds for N=10000. Results are saved in an output directory.

I've tested the code end-to-end and compared the results with the ones from the original R code. Please follow my comments on the benchmarking in the development channel in Slack.